### PR TITLE
feat: add `Search` endpoint

### DIFF
--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -9,6 +9,7 @@ from .scrapers.popular import PopularScraper
 from .scrapers.topten import TopTenScraper
 from .scrapers.most_viewed import MostViewedScraper
 from .scrapers.manga import MangaScraper
+from .scrapers.search import SearchScraper
 # models
 from .models import (
 	PopularMangaModel,
@@ -65,4 +66,5 @@ async def get_manga(slug: str):
 # search mangas
 @router.get("/search")
 async def search(keyword: str):
-	return keyword.replace(" ", "+")
+	response = SearchScraper(keyword).parse()
+	return response

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -68,4 +68,16 @@ async def get_manga(slug: str):
 @router.get("/search", response_model=list[SearchMangaModel])
 async def search(keyword: str):
 	response = SearchScraper(keyword).parse()
-	return response
+	if response:
+		return response
+	else:
+		message = f"Manga not found with query ({keyword}), try another!"
+		status_code = 404
+
+		raise HTTPException(
+			detail = {
+				"message": message,
+				"status_code": status_code
+			},
+			status_code=status_code
+		)

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -61,3 +61,8 @@ async def get_most_viewed(chart: str):
 async def get_manga(slug: str):
 	response = MangaScraper(slug).parse()
 	return response
+
+# search mangas
+@router.get("/search")
+async def search(keyword: str):
+	return keyword.replace(" ", "+")

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -16,7 +16,8 @@ from .models import (
 	BaseModel,
 	TopTenMangaModel,
 	MostViewedMangaModel,
-	MangaModel
+	MangaModel,
+	SearchMangaModel
 )
 
 # router
@@ -64,7 +65,7 @@ async def get_manga(slug: str):
 	return response
 
 # search mangas
-@router.get("/search")
+@router.get("/search", response_model=list[SearchMangaModel])
 async def search(keyword: str):
 	response = SearchScraper(keyword).parse()
 	return response

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -66,10 +66,10 @@ async def get_manga(slug: str):
 
 # search mangas
 @router.get("/search", response_model=list[SearchMangaModel])
-async def search(keyword: str):
+async def search(keyword: str, offset: int = 0, limit: int = Query(10, le=10)):
 	response = SearchScraper(keyword).parse()
 	if response:
-		return response
+		return response[offset: offset+limit]
 	else:
 		message = f"Manga not found with query ({keyword}), try another!"
 		status_code = 404

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -53,8 +53,9 @@ class MangaModel(BaseModel):
 
 class SearchMangaModel(BaseModel):
 	id: int
+	manga_id: int
 	title: str
 	slug: str
 	cover: str
 	langs: list[str]
-	chapters: dict[str, str]
+	chapters: Optional[dict[str, str]]

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -50,3 +50,11 @@ class MangaModel(BaseModel):
 	mangazines: list[str]
 	chapters: list[dict[str, str]]
 	volumes: list[dict[str, str]]
+
+class SearchMangaModel(BaseModel):
+	id: int
+	title: str
+	slug: str
+	cover: str
+	langs: list[str]
+	chapters: dict[str, str]

--- a/app/api/v1/scrapers/manga.py
+++ b/app/api/v1/scrapers/manga.py
@@ -1,5 +1,6 @@
-from selectolax.parser import HTMLParser, Node
 import requests
+from selectolax.parser import HTMLParser, Node
+from ..utils import get_attribute, get_text
 
 class MangaScraper():
 	def __init__(self, slug: str):
@@ -15,16 +16,6 @@ class MangaScraper():
 
 		return HTMLParser(res.content)
 
-	@staticmethod
-	def __get_text(node: Node, selector: str):
-		element = node.css_first(selector)
-		return element.text().strip() if element else None
-
-	@staticmethod
-	def __get_attribute(node: Node, selector: str, attribute: str):
-		element = node.css_first(selector)
-		return element.attributes[attribute] if element else None
-
 	def __get_genres(self, node: Node):
 		genres = node.css(".anisc-detail .sort-desc .genres a")
 		return [genre.text() for genre in genres] if genres else None
@@ -38,14 +29,14 @@ class MangaScraper():
 		return [magazine.text() for magazine in magazines] if magazines else None
 
 	def __get_published(self, node: Node):
-		published_string = self.__get_text(node, ".anisc-detail .anisc-info .item:nth-child(5) .name")
+		published_string = get_text(node, ".anisc-detail .anisc-info .item:nth-child(5) .name")
 		if published_string:
 			date = published_string.split(" to ")[0]
 			return date
 		return None
 
 	def __get_views(self, node: Node):
-		views_string = self.__get_text(node, ".anisc-detail .anisc-info .item:nth-child(7) .name")
+		views_string = get_text(node, ".anisc-detail .anisc-info .item:nth-child(7) .name")
 		return views_string.replace(",", "") if views_string else None
 
 	def __get_chapters_volumes(self, type: str):
@@ -67,16 +58,16 @@ class MangaScraper():
 		node = self.parser.css_first("#ani_detail")
 		manga_dict = {
 			"id": self.slug.split("-")[-1],
-			"title": self.__get_text(node, ".anisc-detail .manga-name"),
-			"alt_title": self.__get_text(node, ".anisc-detail .manga-name-or"),
+			"title": get_text(node, ".anisc-detail .manga-name"),
+			"alt_title": get_text(node, ".anisc-detail .manga-name-or"),
 			"slug": self.slug,
-			"type": self.__get_text(node, ".anisc-detail .anisc-info .item:nth-child(1) a"),
-			"status": self.__get_text(node, ".anisc-detail .anisc-info .item:nth-child(2) .name"),
+			"type": get_text(node, ".anisc-detail .anisc-info .item:nth-child(1) a"),
+			"status": get_text(node, ".anisc-detail .anisc-info .item:nth-child(2) .name"),
 			"published": self.__get_published(node),
-			"score": self.__get_text(node, ".anisc-detail .anisc-info .item:nth-child(6) .name"),
+			"score": get_text(node, ".anisc-detail .anisc-info .item:nth-child(6) .name"),
 			"views": self.__get_views(node),
-			"cover": self.__get_attribute(node, ".anisc-poster .manga-poster-img", "src"),
-			"synopsis": self.__get_text(node, ".anisc-detail .sort-desc .description"),
+			"cover": get_attribute(node, ".anisc-poster .manga-poster-img", "src"),
+			"synopsis": get_text(node, ".anisc-detail .sort-desc .description"),
 			"genres": self.__get_genres(node),
 			"authers": self.__get_authers(node),
 			"mangazines": self.__get_magazines(node),

--- a/app/api/v1/scrapers/most_viewed.py
+++ b/app/api/v1/scrapers/most_viewed.py
@@ -1,11 +1,11 @@
-from selectolax.parser import HTMLParser, Node
 import requests
+from selectolax.parser import HTMLParser, Node
+from ..utils import get_text, get_attribute
 
 class MostViewedScraper:
 	# Charts
 	# eg. "today" | "week" | "month"
 	CHARTS = ["today", "week", "month"]
-
 	def __init__(self):
 		super().__init__()
 
@@ -19,37 +19,27 @@ class MostViewedScraper:
 
 		return HTMLParser(res.content)
 
-	@staticmethod
-	def __get_text(node: Node, selector: str):
-		element = node.css_first(selector)
-		return element.text() if element else None
-
-	@staticmethod
-	def __get_attribute(node: Node, selector: str, attribute: str):
-		element = node.css_first(selector)
-		return element.attributes[attribute] if element else None
-
 	def __get_slug(self, node: Node):
-		slug = self.__get_attribute(node, ".manga-detail .manga-name a", "href")
+		slug = get_attribute(node, ".manga-detail .manga-name a", "href")
 		return slug.replace("/", "") if slug else None
 
 	def __get_cover(self, node: Node):
-		cover = self.__get_attribute(node, "img.manga-poster-img", "src")
+		cover = get_attribute(node, "img.manga-poster-img", "src")
 		return cover.replace("200x300", "500x800") if cover else None
 
 	def __get_views(self, node: Node):
-		views_string = self.__get_text(node, ".fd-infor .fdi-view")
+		views_string = get_text(node, ".fd-infor .fdi-view")
 		if views_string:
 			views = views_string.split()[0].replace(",", "")
 			return views
 		return None
 
 	def __get_langs(self, node: Node):
-		langs_string = self.__get_text(node, ".fd-infor > span:nth-child(1)")
+		langs_string = get_text(node, ".fd-infor > span:nth-child(1)")
 		return [lang for lang in langs_string.split("/")] if langs_string else None
 
 	def __get_chapters_volumes(self, node: Node, index: int):
-		data_string = self.__get_text(node, f".d-block span:nth-child({index})")
+		data_string = get_text(node, f".d-block span:nth-child({index})")
 		return data_string.split()[1] if data_string else None
 
 	def __get_genres(self, node: Node):
@@ -58,8 +48,8 @@ class MostViewedScraper:
 
 	def __build_dict(self, node: Node):
 		manga_dict = {
-			"rank":	self.__get_text(node, ".ranking-number span"),
-			"title": self.__get_text(node, ".manga-detail .manga-name a"),
+			"rank":	get_text(node, ".ranking-number span"),
+			"title": get_text(node, ".manga-detail .manga-name a"),
 			"slug": self.__get_slug(node),
 			"cover": self.__get_cover(node),
 			"views": self.__get_views(node),

--- a/app/api/v1/scrapers/popular.py
+++ b/app/api/v1/scrapers/popular.py
@@ -1,5 +1,6 @@
 import requests
 from selectolax.parser import HTMLParser, Node
+from ..utils import get_attribute, get_text
 
 class PopularScraper:
 	def __init__(self) -> None:
@@ -15,26 +16,16 @@ class PopularScraper:
 
 		return HTMLParser(res.content)
 
-	@staticmethod
-	def __get_text(node: Node, selector: str):
-		element = node.css_first(selector)
-		return element.text() if element else None
-
-	@staticmethod
-	def __get_attribute(node: Node, selector: str, attribute: str):
-		element = node.css_first(selector)
-		return element.attributes[attribute] if element else None
-
 	def __get_slug(self, node: Node):
-		slug = self.__get_attribute(node, "a.link-mask", "href")
+		slug = get_attribute(node, "a.link-mask", "href")
 		return slug.replace("/", "") if slug else None
 
 	def __get_langs(self, node: Node):
-		langs = self.__get_text(node, ".mp-desc p:nth-of-type(3)")
+		langs = get_text(node, ".mp-desc p:nth-of-type(3)")
 		return langs.split("/") if langs else None
 
 	def __get_chapters_volumes(self, node: Node, index: int):
-		data = self.__get_text(node, f".mp-desc p:nth-of-type({index})")
+		data = get_text(node, f".mp-desc p:nth-of-type({index})")
 		if data:
 			total = data.split()[1]
 			lang = data.split()[2].translate(str.maketrans("", "", "[]"))
@@ -49,11 +40,11 @@ class PopularScraper:
 
 	def __build_dict(self, node):
 		manga_dict = {
-			"rank": self.__get_text(node, ".number span"),
-			"title": self.__get_text(node, ".anime-name"),
+			"rank": get_text(node, ".number span"),
+			"title": get_text(node, ".anime-name"),
 			"slug": self.__get_slug(node),
-			"cover": self.__get_attribute(node, "img.manga-poster-img", "src"),
-			"rating": self.__get_text(node, ".mp-desc p:nth-of-type(2)"),
+			"cover": get_attribute(node, "img.manga-poster-img", "src"),
+			"rating": get_text(node, ".mp-desc p:nth-of-type(2)"),
 			"langs": self.__get_langs(node),
 			"chapters": self.__get_chapters_volumes(node, 4),
 			"volumes": self.__get_chapters_volumes(node, 5)

--- a/app/api/v1/scrapers/search.py
+++ b/app/api/v1/scrapers/search.py
@@ -53,7 +53,8 @@ class SearchScraper:
 
 		for index, node in enumerate(node_list, start=1):
 			manga_dict = {
-				"id": self.__get_id(node),
+				"id": index,
+				"manga_id": self.__get_id(node),
 				"title": get_text(node, ".manga-detail .manga-name a"),
 				"slug": self.__get_slug(node),
 				"cover": get_attribute(node, ".manga-poster img", "src"),

--- a/app/api/v1/scrapers/search.py
+++ b/app/api/v1/scrapers/search.py
@@ -1,0 +1,76 @@
+import requests
+from selectolax.parser import HTMLParser, Node
+from ..utils import slugify
+
+class SearchScraper:
+	def __init__(self, keyword):
+		# slugify keyword
+		self.keyword = slugify(keyword, "+")
+		# get parser
+		self.parser = self.__get_parser()
+	
+	def __get_parser(self):
+		url = f"https://mangareader.to/search?keyword={self.keyword}"
+		res = requests.get(url)
+
+		return HTMLParser(res.content)
+
+	@staticmethod
+	def __get_text(node: Node, selector: str):
+		element = node.css_first(selector)
+		return element.text() if element else None
+
+	@staticmethod
+	def __get_attribute(node: Node, selector: str, attribute: str):
+		element = node.css_first(selector)
+		return element.attributes[attribute] if element else None
+
+	def __get_id(self, node):
+		id = self.__get_slug(node)
+		return id.split("-")[-1] if id else None
+
+	def __get_slug(self, node: Node):
+		slug = self.__get_attribute(node, ".manga-detail .manga-name a", "href")
+		return slug.replace("/", "") if slug else None
+
+	def __get_langs(self, node: Node):
+		langs_string = self.__get_text(node, ".manga-poster .tick-lang")
+		return langs_string.split("/") if langs_string else None
+
+	def __get_genres(self, node: Node):
+		genres = node.css(".manga-detail .fd-infor a")
+		return [genre.text() for genre in genres] if genres else None
+
+	def __get_chapters(self, node: Node):
+		data = self.__get_text(node, ".manga-detail .fd-list:nth-child(1) .chapter a")
+		if data:
+			total = data.split()[1]
+			lang = data.split()[2].translate(str.maketrans("", "", "[]"))
+
+			data_dict = {
+				"total": total,
+				"lang": lang
+			}
+
+			return data_dict
+		return None
+
+	def parse(self):
+		manga_list = []
+
+		container = self.parser.css_first(".manga_list-sbs .mls-wrap")
+		node_list = container.css("div.item.item-spc")
+
+		for index, node in enumerate(node_list, start=1):
+			manga_dict = {
+				"id": self.__get_id(node),
+				"title": self.__get_text(node, ".manga-detail .manga-name a"),
+				"slug": self.__get_slug(node),
+				"cover": self.__get_attribute(node, ".manga-poster img", "src"),
+				"langs": self.__get_langs(node),
+				"genres": self.__get_genres(node),
+				"chapters": self.__get_chapters(node),
+			}
+
+			manga_list.append(manga_dict)
+		return manga_list

--- a/app/api/v1/scrapers/search.py
+++ b/app/api/v1/scrapers/search.py
@@ -1,6 +1,6 @@
 import requests
 from selectolax.parser import HTMLParser, Node
-from ..utils import slugify
+from ..utils import slugify, get_text, get_attribute
 
 class SearchScraper:
 	def __init__(self, keyword):
@@ -15,26 +15,16 @@ class SearchScraper:
 
 		return HTMLParser(res.content)
 
-	@staticmethod
-	def __get_text(node: Node, selector: str):
-		element = node.css_first(selector)
-		return element.text() if element else None
-
-	@staticmethod
-	def __get_attribute(node: Node, selector: str, attribute: str):
-		element = node.css_first(selector)
-		return element.attributes[attribute] if element else None
-
 	def __get_id(self, node):
 		id = self.__get_slug(node)
 		return id.split("-")[-1] if id else None
 
 	def __get_slug(self, node: Node):
-		slug = self.__get_attribute(node, ".manga-detail .manga-name a", "href")
+		slug = get_attribute(node, ".manga-detail .manga-name a", "href")
 		return slug.replace("/", "") if slug else None
 
 	def __get_langs(self, node: Node):
-		langs_string = self.__get_text(node, ".manga-poster .tick-lang")
+		langs_string = get_text(node, ".manga-poster .tick-lang")
 		return langs_string.split("/") if langs_string else None
 
 	def __get_genres(self, node: Node):
@@ -42,7 +32,7 @@ class SearchScraper:
 		return [genre.text() for genre in genres] if genres else None
 
 	def __get_chapters(self, node: Node):
-		data = self.__get_text(node, ".manga-detail .fd-list:nth-child(1) .chapter a")
+		data = get_text(node, ".manga-detail .fd-list:nth-child(1) .chapter a")
 		if data:
 			total = data.split()[1]
 			lang = data.split()[2].translate(str.maketrans("", "", "[]"))
@@ -64,12 +54,12 @@ class SearchScraper:
 		for index, node in enumerate(node_list, start=1):
 			manga_dict = {
 				"id": self.__get_id(node),
-				"title": self.__get_text(node, ".manga-detail .manga-name a"),
+				"title": get_text(node, ".manga-detail .manga-name a"),
 				"slug": self.__get_slug(node),
-				"cover": self.__get_attribute(node, ".manga-poster img", "src"),
+				"cover": get_attribute(node, ".manga-poster img", "src"),
 				"langs": self.__get_langs(node),
 				"genres": self.__get_genres(node),
-				"chapters": self.__get_chapters(node),
+				"chapters": self.__get_chapters(node)
 			}
 
 			manga_list.append(manga_dict)

--- a/app/api/v1/scrapers/topten.py
+++ b/app/api/v1/scrapers/topten.py
@@ -1,5 +1,6 @@
-from selectolax.parser import HTMLParser, Node
 import requests
+from selectolax.parser import HTMLParser, Node
+from ..utils import get_text, get_attribute
 
 class TopTenScraper():
     def __init__(self):
@@ -15,22 +16,12 @@ class TopTenScraper():
 
         return HTMLParser(res.content)
 
-    @staticmethod
-    def __get_text(node: Node, selector: str):
-        element = node.css_first(selector)
-        return element.text() if element else None
-
-    @staticmethod
-    def __get_attribute(node: Node, selector: str, attribute: str):
-        element = node.css_first(selector)
-        return element.attributes[attribute] if element else None
-
     def __get_slug(self, node: Node):
-        slug = self.__get_attribute(node, ".desi-head-title a", "href")
+        slug = get_attribute(node, ".desi-head-title a", "href")
         return slug.replace("/", "") if slug else None
 
     def __get_chapters(self, node: Node):
-        chapters_string = self.__get_text(node, ".desi-sub-text")
+        chapters_string = get_text(node, ".desi-sub-text")
         if chapters_string:
             total = chapters_string.split()[1]
             lang = chapters_string.split()[2].translate(str.maketrans("", "", "[]"))
@@ -49,10 +40,10 @@ class TopTenScraper():
 
     def __build_dict(self, node: Node):
         manga_dict = {
-            "title": self.__get_text(node, ".desi-head-title a"),
+            "title": get_text(node, ".desi-head-title a"),
             "slug": self.__get_slug(node),
-            "cover": self.__get_attribute(node, "img.manga-poster-img", "src"),
-            "synopsis": self.__get_text(node, ".sc-detail .scd-item"),
+            "cover": get_attribute(node, "img.manga-poster-img", "src"),
+            "synopsis": get_text(node, ".sc-detail .scd-item"),
             "chapters": self.__get_chapters(node),
             "genres": self.__get_genres(node)
         }

--- a/app/api/v1/utils.py
+++ b/app/api/v1/utils.py
@@ -1,0 +1,10 @@
+import re
+
+def slugify(str: str, symbol: str):
+	""" Makes lowercase and strip spaces and replace space between words with "+" symbol """
+	str = str.lower().strip()
+	str = re.sub(r'[^\w\s-]', '', str)
+	str = re.sub(r'[\s_-]+', f'{symbol}', str)
+	str = re.sub(r'^-+|-+$', '', str)
+
+	return str

--- a/app/api/v1/utils.py
+++ b/app/api/v1/utils.py
@@ -1,10 +1,22 @@
 import re
+from selectolax.parser import Node
 
+# Scraper funcions
+def get_text(node: Node, selector: str):
+	""" get text from a node according to css selector """
+	element = node.css_first(selector)
+	return element.text() if element else None
+
+def get_attribute(node: Node, selector: str, attribute: str):
+	""" get content from a node according to css selector and attribute """
+	element = node.css_first(selector)
+	return element.attributes[attribute] if element else None
+
+# Other functions
 def slugify(str: str, symbol: str):
 	""" Makes lowercase and strip spaces and replace space between words with "+" symbol """
 	str = str.lower().strip()
 	str = re.sub(r'[^\w\s-]', '', str)
 	str = re.sub(r'[\s_-]+', f'{symbol}', str)
 	str = re.sub(r'^-+|-+$', '', str)
-
 	return str


### PR DESCRIPTION
**Changes**
This PR comes with a new endpoint: `search` endpoint, which search mangas and returns a list.
usage eg: `/v1/search/?keyword=one piece/`
returns a list of related mangas.

Also this slugify keyword, for eg: `One piece` converts into `one+piece`
**Tasks**
- [X] Endpoint
- [x] Response model
- [x] Offset and Limit
