### PR TITLE
feat: new `Completed` endpoint

### DIFF
--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -9,7 +9,7 @@ from .scrapers.most_viewed import MostViewedScraper
 from .scrapers.manga import MangaScraper
 from .scrapers.search import SearchScraper
 from .scrapers.random import RandomScraper
-from .scrapers.base_genre import BaseGenreScraper
+from .scrapers.base_search import BaseSearchScraper
 # models
 from .models import (
 	PopularMangaModel,
@@ -116,7 +116,7 @@ async def random():
 
 @router.get("/completed")
 @handle_exceptions("Something went wrong, please try again!", 503)
-async def completed(page: int = 1):
-	url = f"https://mangareader.to/completed/?page={page}"
-	response = BaseGenreScraper(url).scrape()
+async def completed(page: int = 1, sort: str = "default"):
+	url = f"https://mangareader.to/completed/?sort={sort}&page={page}"
+	response = BaseSearchScraper(url).scrape()
 	return response

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -9,6 +9,7 @@ from .scrapers.most_viewed import MostViewedScraper
 from .scrapers.manga import MangaScraper
 from .scrapers.search import SearchScraper
 from .scrapers.random import RandomScraper
+from .scrapers.base_genre import BaseGenreScraper
 # models
 from .models import (
 	PopularMangaModel,
@@ -111,4 +112,11 @@ async def search(keyword: str, page: int = 1, offset: int = 0, limit: int = Quer
 @handle_exceptions("Something went wrong, please try again!", 503)
 async def random():
 	response = RandomScraper().scrape()
+	return response
+
+@router.get("/completed")
+@handle_exceptions("Something went wrong, please try again!", 503)
+async def completed(page: int = 1):
+	url = f"https://mangareader.to/completed/?page={page}"
+	response = BaseGenreScraper(url).scrape()
 	return response

--- a/app/api/v1/scrapers/base_genre.py
+++ b/app/api/v1/scrapers/base_genre.py
@@ -1,0 +1,62 @@
+import requests
+from selectolax.parser import HTMLParser, Node
+from ..utils import slugify, get_text, get_attribute
+
+class BaseGenreScraper:
+	def __init__(self, url: str):
+		self.url = url
+		self.parser = self.__get_parser()
+
+	def __get_parser(self):
+		res = requests.get(self.url)
+		return HTMLParser(res.content)
+
+	def __get_id(self, node: Node):
+		id = self.__get_slug(node)
+		return id.split("-")[-1] if id else None
+
+	def __get_slug(self, node: Node):
+		slug = get_attribute(node, ".manga-detail .manga-name a", "href")
+		return slug.replace("/", "") if slug else None
+
+	def __get_langs(self, node: Node):
+		langs_string = get_text(node, ".manga-poster .tick-lang")
+		return langs_string.split("/") if langs_string else None
+
+	def __get_genres(self, node: Node):
+		genres = node.css(".manga-detail .fd-infor a")
+		return [genre.text() for genre in genres] if genres else None
+
+	def __get_chapters(self, node: Node):
+		data = get_text(node, ".manga-detail .fd-list:nth-child(1) .chapter a")
+		if data:
+			total = data.split()[1]
+			lang = data.split()[2].translate(str.maketrans("", "", "[]"))
+
+			data_dict = {
+				"total": total,
+				"lang": lang
+			}
+
+			return data_dict
+		return None
+
+	def scrape(self) -> list:
+		manga_list = []
+		container = self.parser.css_first(".manga_list-sbs")
+		node_list = container.css("div.item.item-spc")
+
+		for index, node in enumerate(node_list, start=1):
+			manga_dict = {
+				"id": index,
+				"manga_id": self.__get_id(node),
+				"title": get_text(node, ".manga-detail .manga-name a"),
+				"slug": self.__get_slug(node),
+				"cover": get_attribute(node, ".manga-poster img", "src"),
+				"langs": self.__get_langs(node),
+				"genres": self.__get_genres(node),
+				"chapters": self.__get_chapters(node)
+			}
+
+			manga_list.append(manga_dict)
+		return manga_list

--- a/app/api/v1/scrapers/base_search.py
+++ b/app/api/v1/scrapers/base_search.py
@@ -2,7 +2,7 @@ import requests
 from selectolax.parser import HTMLParser, Node
 from ..utils import slugify, get_text, get_attribute
 
-class BaseGenreScraper:
+class BaseSearchScraper:
 	def __init__(self, url: str):
 		self.url = url
 		self.parser = self.__get_parser()


### PR DESCRIPTION
**Changes**
Added new endpoint: `/completed/`, which returns a list of Manga which is completed airing.
Available queries:
| Query    | Description |
| -------- | ------- |
| page  | Specific page of mangas    |
| sort | Sorting type     |
| offset    | kinda skip mangas    |
| limit | limit no:of mangas response |

Closes #26 