### PR TITLE
feat: new `/genre/` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Python-based web scraping tool built with FastAPI that provides easy access to m
             </td>
             <td><code>sort</code> - <code>default</code> <code>last-updated</code> <code>score</code> <code>name-ax</code> <code>release-date</code> <code>most-viewed</code> eg: <code>/completed/?sort=last-updated&page=2</code> (basic queries)</td>
         </tr>
+        <tr>
+            <td><code>/v1/genre/</code></td>
+            <td>
+                <code>genre</code>
+                <code>sort</code>
+                <code>page</code>
+                (basic queries)
+            </td>
+            <td><code>sort</code> - <code>default</code> <code>last-updated</code> <code>score</code> <code>name-ax</code> <code>release-date</code> <code>most-viewed</code> eg: <code>/completed/?sort=last-updated&page=2</code> (basic queries)</td>
+        </tr>
     </tbody>
 </table>
 

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -105,3 +105,9 @@ async def completed(page: int = 1, sort: str = "default", offset: int = 0, limit
 	url = f"https://mangareader.to/completed/?sort={slugified_sort}&page={page}"
 	response = BaseSearchScraper(url).scrape()
 	return response[offset: offset+limit]
+
+@router.get("/genre/{genre}")
+async def genre(genre: str):
+	url = f"https://mangareader.to/genre/{genre}"
+	response = BaseSearchScraper(url).scrape()
+	return response

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -111,7 +111,10 @@ async def completed(
 	response = BaseSearchScraper(url).scrape()
 	return response[offset: offset+limit]
 
-@router.get("/genre/{genre}")
+@router.get(
+	"/genre/{genre}",
+	response_model=list[BaseSearchModel]
+)
 async def genre(
 	genre: str,
 	page: int = 1,

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -107,7 +107,8 @@ async def completed(page: int = 1, sort: str = "default", offset: int = 0, limit
 	return response[offset: offset+limit]
 
 @router.get("/genre/{genre}")
-async def genre(genre: str):
-	url = f"https://mangareader.to/genre/{genre}"
+async def genre(genre: str, page: int = 1, sort: str = "default", offset: int = 0, limit: int = Query(10, le=18)):
+	slugified_sort = slugify(sort, "-")
+	url = f"https://mangareader.to/genre/{genre}/?sort={slugified_sort}&page={page}"
 	response = BaseSearchScraper(url).scrape()
-	return response
+	return response[offset: offset+limit]

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -100,14 +100,25 @@ async def random():
 	summary="Completed Mangas",
 	description="Get list of completed airing Mangas. eg: `/completed/` - returns a list of Mangas which is completed airing lately. Also has `sort` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `sort` queries - `default` `last-updated` `score` `name-az` `release-date` `most-viewed`."
 )
-async def completed(page: int = 1, sort: str = "default", offset: int = 0, limit: int = Query(10, le=18)):
+async def completed(
+	page: int = 1,
+	sort: str = "default",
+	offset: int = 0,
+	limit: int = Query(10, le=18)
+):
 	slugified_sort = slugify(sort, "-")
 	url = f"https://mangareader.to/completed/?sort={slugified_sort}&page={page}"
 	response = BaseSearchScraper(url).scrape()
 	return response[offset: offset+limit]
 
 @router.get("/genre/{genre}")
-async def genre(genre: str, page: int = 1, sort: str = "default", offset: int = 0, limit: int = Query(10, le=18)):
+async def genre(
+	genre: str,
+	page: int = 1,
+	sort: str = "default",
+	offset: int = 0,
+	limit: int = Query(10, le=18)
+):
 	slugified_sort = slugify(sort, "-")
 	url = f"https://mangareader.to/genre/{genre}/?sort={slugified_sort}&page={page}"
 	response = BaseSearchScraper(url).scrape()

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -113,7 +113,9 @@ async def completed(
 
 @router.get(
 	"/genre/{genre}",
-	response_model=list[BaseSearchModel]
+	response_model=list[BaseSearchModel],
+	summary="Genre",
+	description="Search Mangas with genres. eg: `/genre/action/` - returns a list of Mangas with genre `action`. Also has `sort` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `sort` queries - `default` `last-updated` `score` `name-az` `release-date` `most-viewed`."
 )
 async def genre(
 	genre: str,


### PR DESCRIPTION
**Changes**
Added new endpoint: `/genre/{genre}`, which returns a list of Manga which is completed airing.
eg url: `genre/action?page=2&sort=score&offset=5&limit=5`
Available queries:
| Query    | Description |
| -------- | ------- |
| genre | Genre to be searched |
| page  | Specific page of mangas    |
| sort | Sorting type     |
| offset    | kinda skip mangas    |
| limit | limit no:of mangas response |

Closes #32 