### PR TITLE
feat: new endpoint `/type/`

### DIFF
--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -135,7 +135,12 @@ async def genre(
     response = BaseSearchScraper(url).scrape()
     return response[offset : offset + limit]
 
-@router.get("/type/{type}")
+@router.get(
+	"/type/{type}",
+	response_model=list[BaseSearchModel],
+	summary="Genre",
+    description="Search Mangas with genres. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `manga` `one-shot` `doujinshi` `ight-novel` `manhwa` `manhua` `comic`.",
+)
 def type(
 	type: str,
     page: int = 1,

--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -134,3 +134,16 @@ async def genre(
     url = f"https://mangareader.to/genre/{genre}/?sort={slugified_sort}&page={page}"
     response = BaseSearchScraper(url).scrape()
     return response[offset : offset + limit]
+
+@router.get("/type/{type}")
+def type(
+	type: str,
+    page: int = 1,
+    sort: str = "default",
+    offset: int = 0,
+    limit: int = Query(10, le=18),
+):
+	slugified_sort = slugify(sort, "-")
+	url = f"https://mangareader.to/type/{type}?sort={slugified_sort}&page={page}"
+	response = BaseSearchScraper(url).scrape()
+	return response[offset : offset + limit]


### PR DESCRIPTION
Add new endpoint: `/type/` - returns list of mangas with specific endpoint.
includes extra `type` query: which is the type of mangas.
valid values are `manga` `one-shot` `doujinshi` `ight-novel` `manhwa` `manhua` `comic`

also includes other filter queries.
Closes #36 