### PR TITLE
fix: Typo in summary and description of `/type/` endpoint

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -140,7 +140,7 @@ async def genre(
     "/type/{type}",
     response_model=list[BaseSearchModel],
     summary="Type",
-    description="Search Mangas with types. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `Manga`, `One-shot`, `Doujinshi`, `Light-novel`, `Manhwa`, `Manhua`, `Comic`.",
+    description="Search Mangas with types. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `manga`, `one-shot`, `doujinshi`, `light-novel`, `manhwa`, `manhua`, `comic`.",
 )
 def type(
     type: str,
@@ -149,7 +149,8 @@ def type(
     offset: int = 0,
     limit: int = Query(10, le=18),
 ):
+    slugified_type = string_helper.slugify(type, "-")
     slugified_sort = string_helper.slugify(sort, "-")
-    url = f"https://mangareader.to/type/{type}?sort={slugified_sort}&page={page}"
+    url = f"https://mangareader.to/type/{slugified_type}?sort={slugified_sort}&page={page}"
     response = BaseSearchScraper(url).scrape()
     return response[offset : offset + limit]

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -140,7 +140,7 @@ async def genre(
     "/type/{type}",
     response_model=list[BaseSearchModel],
     summary="Type",
-    description="Search Mangas with types. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `Manga`, `One-shot`, `Doujinshi`, `Light`, `Manhwa`, `Manhua`, `Comic`.",
+    description="Search Mangas with types. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `Manga`, `One-shot`, `Doujinshi`, `Light-novel`, `Manhwa`, `Manhua`, `Comic`.",
 )
 def type(
     type: str,

--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -139,8 +139,8 @@ async def genre(
 @router.get(
     "/type/{type}",
     response_model=list[BaseSearchModel],
-    summary="Genre",
-    description="Search Mangas with genres. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `manga` `one-shot` `doujinshi` `ight-novel` `manhwa` `manhua` `comic`.",
+    summary="Type",
+    description="Search Mangas with types. eg: `/type/manga/` - returns a list of Mangas with type `manga`. Also has `page` query which get each pages of Mangas ( 1 page contains 18 Mangas ): valid `type` queries - `Manga`, `One-shot`, `Doujinshi`, `Light`, `Manhwa`, `Manhua`, `Comic`.",
 )
 def type(
     type: str,


### PR DESCRIPTION
Closes #43 
Fix typos in endpoint:
- summary: `Genre` -> `Type`
- description: `genre` -> `type`, `ight-novel` -> `light` 