### PR TITLE
refactor: move `__get_parser` to `helpers`

### DIFF
--- a/app/api/endpoints.py
+++ b/app/api/endpoints.py
@@ -18,6 +18,7 @@ from .models.base_manga import MangaModel
 from .models.base_search import BaseSearchModel
 
 router = APIRouter()
+# Facades
 string_helper = StringHelper()
 
 

--- a/app/api/helpers/html_helper.py
+++ b/app/api/helpers/html_helper.py
@@ -1,0 +1,9 @@
+import requests
+from selectolax.parser import HTMLParser
+
+
+class HTMLHelper:
+    @staticmethod
+    def get_parser(url: str) -> HTMLParser:
+        res = requests.get(url) 
+        return HTMLParser(res.content)

--- a/app/api/scrapers/base_manga.py
+++ b/app/api/scrapers/base_manga.py
@@ -2,17 +2,14 @@ import requests
 from selectolax.parser import HTMLParser
 from ..decorators.return_decorator import return_on_error
 from ..helpers.string import StringHelper
+from ..helpers.html_helper import HTMLHelper
 
 
 class BaseMangaScraper:
     def __init__(self, url: str) -> None:
         self.url = url
-        self.parser = self.__get_parser()
+        self.parser = HTMLHelper.get_parser(url)
         self.string_helper = StringHelper()
-
-    def __get_parser(self) -> HTMLParser:
-        res = requests.get(self.url)
-        return HTMLParser(res.content)
 
     @property
     @return_on_error(0)

--- a/app/api/scrapers/base_manga.py
+++ b/app/api/scrapers/base_manga.py
@@ -5,8 +5,11 @@ from ..helpers.html_helper import HTMLHelper
 
 class BaseMangaScraper:
     def __init__(self, url: str) -> None:
-        self.parser = HTMLHelper.get_parser(url)
+        # Facades
         self.string_helper = StringHelper()
+        self.html_helper = HTMLHelper()
+        # Parser
+        self.parser = self.html_helper.get_parser(url)
 
     @property
     @return_on_error(0)

--- a/app/api/scrapers/base_manga.py
+++ b/app/api/scrapers/base_manga.py
@@ -1,5 +1,3 @@
-import requests
-from selectolax.parser import HTMLParser
 from ..decorators.return_decorator import return_on_error
 from ..helpers.string import StringHelper
 from ..helpers.html_helper import HTMLHelper
@@ -7,7 +5,6 @@ from ..helpers.html_helper import HTMLHelper
 
 class BaseMangaScraper:
     def __init__(self, url: str) -> None:
-        self.url = url
         self.parser = HTMLHelper.get_parser(url)
         self.string_helper = StringHelper()
 

--- a/app/api/scrapers/base_search.py
+++ b/app/api/scrapers/base_search.py
@@ -1,16 +1,12 @@
-import requests
-from selectolax.parser import HTMLParser, Node
+from selectolax.parser import Node
 from ..decorators.return_decorator import return_on_error
+from ..helpers.html_helper import HTMLHelper
 
 
 class BaseSearchScraper:
     def __init__(self, url: str):
         self.url = url
-        self.parser = self.__get_parser()
-
-    def __get_parser(self):
-        res = requests.get(self.url)
-        return HTMLParser(res.content)
+        self.parser = HTMLHelper.get_parser(url)
 
     def get_manga_id(self, node: Node):
         id = self.get_slug(node)

--- a/app/api/scrapers/base_search.py
+++ b/app/api/scrapers/base_search.py
@@ -5,7 +5,10 @@ from ..helpers.html_helper import HTMLHelper
 
 class BaseSearchScraper:
     def __init__(self, url: str):
-        self.parser = HTMLHelper.get_parser(url)
+        # Facades
+        self.html_helper = HTMLHelper()
+        # Parser
+        self.parser = self.html_helper.get_parser(url)
 
     def get_manga_id(self, node: Node):
         id = self.get_slug(node)

--- a/app/api/scrapers/base_search.py
+++ b/app/api/scrapers/base_search.py
@@ -5,7 +5,6 @@ from ..helpers.html_helper import HTMLHelper
 
 class BaseSearchScraper:
     def __init__(self, url: str):
-        self.url = url
         self.parser = HTMLHelper.get_parser(url)
 
     def get_manga_id(self, node: Node):

--- a/app/api/scrapers/most_viewed.py
+++ b/app/api/scrapers/most_viewed.py
@@ -1,6 +1,6 @@
-import requests
-from selectolax.parser import HTMLParser, Node
+from selectolax.parser import Node
 from ..utils import get_text, get_attribute
+from ..helpers.html_helper import HTMLHelper
 
 
 class MostViewedScraper:
@@ -10,13 +10,7 @@ class MostViewedScraper:
 
     def __init__(self) -> None:
         # get parser
-        self.parser = self.__get_parser()
-
-    @staticmethod
-    def __get_parser() -> HTMLParser:
-        url = "https://mangareader.to/home"
-        res = requests.get(url)
-        return HTMLParser(res.content)
+        self.parser = HTMLHelper.get_parser(url="https://mangareader.to/home")
 
     def __get_slug(self, node: Node) -> str | None:
         slug = get_attribute(node, ".manga-detail .manga-name a", "href")

--- a/app/api/scrapers/most_viewed.py
+++ b/app/api/scrapers/most_viewed.py
@@ -9,8 +9,10 @@ class MostViewedScraper:
     CHARTS = ["today", "week", "month"]
 
     def __init__(self) -> None:
-        # get parser
-        self.parser = HTMLHelper.get_parser(url="https://mangareader.to/home")
+        # Facades
+        self.html_helper = HTMLHelper()
+        # Parser
+        self.parser = self.html_helper.get_parser(url="https://mangareader.to/home")
 
     def __get_slug(self, node: Node) -> str | None:
         slug = get_attribute(node, ".manga-detail .manga-name a", "href")

--- a/app/api/scrapers/most_viewed.py
+++ b/app/api/scrapers/most_viewed.py
@@ -9,10 +9,11 @@ class MostViewedScraper:
     CHARTS = ["today", "week", "month"]
 
     def __init__(self) -> None:
+        url = "https://mangareader.to/home"
         # Facades
         self.html_helper = HTMLHelper()
         # Parser
-        self.parser = self.html_helper.get_parser(url="https://mangareader.to/home")
+        self.parser = self.html_helper.get_parser(url)
 
     def __get_slug(self, node: Node) -> str | None:
         slug = get_attribute(node, ".manga-detail .manga-name a", "href")

--- a/app/api/scrapers/popular.py
+++ b/app/api/scrapers/popular.py
@@ -5,10 +5,11 @@ from ..helpers.html_helper import HTMLHelper
 
 class PopularScraper:
     def __init__(self) -> None:
+        url = "https://mangareader.to/home"
         # Facades
         self.html_helper = HTMLHelper()
         # Parser
-        self.parser = self.html_helper.get_parser(url="https://mangareader.to/home")
+        self.parser = self.html_helper.get_parser(url)
 
     @staticmethod
     def __get_slug(node: Node) -> str | None:

--- a/app/api/scrapers/popular.py
+++ b/app/api/scrapers/popular.py
@@ -1,18 +1,12 @@
-import requests
-from selectolax.parser import HTMLParser, Node
+from selectolax.parser import Node
 from ..utils import get_attribute, get_text
+from ..helpers.html_helper import HTMLHelper
 
 
 class PopularScraper:
     def __init__(self) -> None:
         # get parser
-        self.parser = self.__get_parser()
-
-    @staticmethod
-    def __get_parser() -> HTMLParser:
-        url = "https://mangareader.to/home"
-        res = requests.get(url)
-        return HTMLParser(res.content)
+        self.parser = HTMLHelper.get_parser(url="https://mangareader.to/home")
 
     @staticmethod
     def __get_slug(node: Node) -> str | None:

--- a/app/api/scrapers/popular.py
+++ b/app/api/scrapers/popular.py
@@ -5,8 +5,10 @@ from ..helpers.html_helper import HTMLHelper
 
 class PopularScraper:
     def __init__(self) -> None:
-        # get parser
-        self.parser = HTMLHelper.get_parser(url="https://mangareader.to/home")
+        # Facades
+        self.html_helper = HTMLHelper()
+        # Parser
+        self.parser = self.html_helper.get_parser(url="https://mangareader.to/home")
 
     @staticmethod
     def __get_slug(node: Node) -> str | None:

--- a/app/api/scrapers/topten.py
+++ b/app/api/scrapers/topten.py
@@ -5,7 +5,10 @@ from ..helpers.html_helper import HTMLHelper
 
 class TopTenScraper:
     def __init__(self) -> None:
-        self.parser = HTMLHelper.get_parser(url="https://mangareader.to/home")
+        # Facades
+        self.html_helper = HTMLHelper()
+        # Parser
+        self.parser = self.html_helper.get_parser(url="https://mangareader.to/home")
 
     def __get_slug(self, node: Node) -> str | None:
         slug = get_attribute(node, ".desi-head-title a", "href")

--- a/app/api/scrapers/topten.py
+++ b/app/api/scrapers/topten.py
@@ -1,18 +1,11 @@
-import requests
-from selectolax.parser import HTMLParser, Node
+from selectolax.parser import Node
 from ..utils import get_text, get_attribute
+from ..helpers.html_helper import HTMLHelper
 
 
 class TopTenScraper:
     def __init__(self) -> None:
-        self.parser = self.__get_parser()
-
-    @staticmethod
-    def __get_parser() -> HTMLParser:
-        url = "https://mangareader.to/home"
-        res = requests.get(url)
-
-        return HTMLParser(res.content)
+        self.parser = HTMLHelper.get_parser(url="https://mangareader.to/home")
 
     def __get_slug(self, node: Node) -> str | None:
         slug = get_attribute(node, ".desi-head-title a", "href")

--- a/app/api/scrapers/topten.py
+++ b/app/api/scrapers/topten.py
@@ -5,10 +5,11 @@ from ..helpers.html_helper import HTMLHelper
 
 class TopTenScraper:
     def __init__(self) -> None:
+        url = "https://mangareader.to/home"
         # Facades
         self.html_helper = HTMLHelper()
         # Parser
-        self.parser = self.html_helper.get_parser(url="https://mangareader.to/home")
+        self.parser = self.html_helper.get_parser(url)
 
     def __get_slug(self, node: Node) -> str | None:
         slug = get_attribute(node, ".desi-head-title a", "href")


### PR DESCRIPTION
fix #42
Changes:
- move `__get_parser()` to class `HTMLHelper` in `/api/helpers/html_helper.py`
- new `get_parser()` take `url`
- change all occurences `self.__get_parsers()` to `HTMLHelper.get_parser()`
- delete unused imports in 4-5 files